### PR TITLE
Backlog API が返す JSON が壊れていることがあるので、JSON_ERROR_SYNTAX は許容する

### DIFF
--- a/src/Backlog.php
+++ b/src/Backlog.php
@@ -131,7 +131,7 @@ class Backlog
 			// error
 			throw new BacklogException($json['errors'][0]['message'], $json['errors'][0]['code'], null, $json);
 		}
-		// Backlog API が返す JSON が常に壊れているようなので、JSON_ERROR_SYNTAX は許容する
+		// Backlog API が返す JSON が壊れていることがあるので、JSON_ERROR_SYNTAX は許容する
 		elseif ('application/json' == $type and JSON_ERROR_NONE !== $json_error and JSON_ERROR_SYNTAX !== $json_error){
 			// error
 			throw new BacklogException('json error.', $json_error, null, $response);

--- a/src/Backlog.php
+++ b/src/Backlog.php
@@ -131,7 +131,8 @@ class Backlog
 			// error
 			throw new BacklogException($json['errors'][0]['message'], $json['errors'][0]['code'], null, $json);
 		}
-		elseif ('application/json' == $type and JSON_ERROR_NONE !== $json_error){
+		// Backlog API が返す JSON が常に壊れているようなので、JSON_ERROR_SYNTAX は許容する
+		elseif ('application/json' == $type and JSON_ERROR_NONE !== $json_error and JSON_ERROR_SYNTAX !== $json_error){
 			// error
 			throw new BacklogException('json error.', $json_error, null, $response);
 		}


### PR DESCRIPTION
Backlog API が返す JSON が壊れていることがあるので、JSON_ERROR_SYNTAX は許容する
